### PR TITLE
Show the title and author of the text

### DIFF
--- a/speed-type.el
+++ b/speed-type.el
@@ -8,18 +8,20 @@
 ;; URL: https://github.com/hagleitn/speed-type
 ;; Package-Requires: ((cl-lib "0.3"))
 
-;; This program is free software; you can redistribute it and/or modify
+;; This file is NOT part of GNU Emacs.
+
+;; GNU Emacs is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
 ;; the Free Software Foundation, either version 3 of the License, or
 ;; (at your option) any later version.
 
-;; This program is distributed in the hope that it will be useful,
+;; GNU Emacs is distributed in the hope that it will be useful,
 ;; but WITHOUT ANY WARRANTY; without even the implied warranty of
 ;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ;; GNU General Public License for more details.
 
 ;; You should have received a copy of the GNU General Public License
-;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+;; along with GNU Emacs.  If not, see <http://www.gnu.org/licenses/>.
 
 ;;; Commentary:
 ;;
@@ -167,6 +169,12 @@ Total errors:\t%d
 (defvar speed-type--corrections 0)
 (make-variable-buffer-local 'speed-type--corrections)
 
+(defvar speed-type--title nil)
+;;(make-variable-buffer-local 'speed-type--title)
+
+(defvar speed-type--author nil)
+;;(make-variable-buffer-local 'speed-type--author)
+
 (defun speed-type--elapsed-time ()
   "Return float with the total time since start."
   (let ((end-time (float-time)))
@@ -274,6 +282,9 @@ are color coded and stats are gathered about the typing performance."
     (setq speed-type--remaining (length text))
     (erase-buffer)
     (insert speed-type--orig-text)
+    (insert (propertize
+             (format "\n\n\n%s, by %s" speed-type--title speed-type--author)
+             'face 'italic))
     (not-modified)
     (switch-to-buffer buf)
     (goto-char 0)
@@ -313,6 +324,12 @@ are color coded and stats are gathered about the typing performance."
          (tries 20))
     (with-current-buffer (speed-type--gb-retrieve book-num)
       (goto-char 0)
+      (setq speed-type--title
+            (buffer-substring (goto-char (re-search-forward "^Title: "))
+                              (line-end-position)))
+      (setq speed-type--author
+            (buffer-substring (goto-char (re-search-forward "^Author: "))
+                              (line-end-position)))
       (dotimes (i paragraph-num nil)
         (setq p (point))
         (if fwd (forward-paragraph)

--- a/speed-type.el
+++ b/speed-type.el
@@ -279,9 +279,10 @@ are color coded and stats are gathered about the typing performance."
     (setq speed-type--remaining (length text))
     (erase-buffer)
     (insert speed-type--orig-text)
-    (insert (propertize
-             (format "\n\n\n%s, by %s" speed-type--title speed-type--author)
-             'face 'italic))
+    (when speed-type--title
+      (insert (propertize
+               (format "\n\n\n%s, by %s" speed-type--title speed-type--author)
+               'face 'italic)))
     (not-modified)
     (switch-to-buffer buf)
     (goto-char 0)
@@ -321,11 +322,12 @@ are color coded and stats are gathered about the typing performance."
          (tries 20))
     (with-current-buffer (speed-type--gb-retrieve book-num)
       (goto-char 0)
+      (princ (speed-type--gb-retrieve book-num))
       (setq speed-type--title
-            (buffer-substring (goto-char (re-search-forward "^Title: "))
+            (buffer-substring (goto-char (re-search-forward "^Title: " nil t))
                               (line-end-position)))
       (setq speed-type--author
-            (buffer-substring (goto-char (re-search-forward "^Author: "))
+            (buffer-substring (goto-char (re-search-forward "^Author: " nil t))
                               (line-end-position)))
       (dotimes (i paragraph-num nil)
         (setq p (point))

--- a/speed-type.el
+++ b/speed-type.el
@@ -170,10 +170,7 @@ Total errors:\t%d
 (make-variable-buffer-local 'speed-type--corrections)
 
 (defvar speed-type--title nil)
-;;(make-variable-buffer-local 'speed-type--title)
-
 (defvar speed-type--author nil)
-;;(make-variable-buffer-local 'speed-type--author)
 
 (defun speed-type--elapsed-time ()
   "Return float with the total time since start."

--- a/speed-type.el
+++ b/speed-type.el
@@ -108,7 +108,7 @@ Total errors:\t%d
 %s")
 
 (defun speed-type--generate-stats (entries errors corrections seconds)
-  "Return string of statistics with the title and author."
+  "Return string of statistics."
   (format speed-type-stats-format
           (speed-type--skill (speed-type--net-wpm entries errors seconds))
           (speed-type--net-wpm entries errors seconds)

--- a/speed-type.el
+++ b/speed-type.el
@@ -279,7 +279,7 @@ are color coded and stats are gathered about the typing performance."
     (setq speed-type--remaining (length text))
     (erase-buffer)
     (insert speed-type--orig-text)
-    (when speed-type--title
+    (when (and speed-type--title speed-type--author)
       (insert (propertize
                (format "\n\n\n%s, by %s" speed-type--title speed-type--author)
                'face 'italic)))
@@ -322,13 +322,12 @@ are color coded and stats are gathered about the typing performance."
          (tries 20))
     (with-current-buffer (speed-type--gb-retrieve book-num)
       (goto-char 0)
-      (princ (speed-type--gb-retrieve book-num))
-      (setq speed-type--title
-            (buffer-substring (goto-char (re-search-forward "^Title: " nil t))
-                              (line-end-position)))
-      (setq speed-type--author
-            (buffer-substring (goto-char (re-search-forward "^Author: " nil t))
-                              (line-end-position)))
+      (when (re-search-forward "^Title: " nil t)
+        (setq speed-type--title
+              (buffer-substring (point) (line-end-position))))
+      (when (re-search-forward "^Author: " nil t)
+        (setq speed-type--author
+              (buffer-substring (point) (line-end-position))))
       (dotimes (i paragraph-num nil)
         (setq p (point))
         (if fwd (forward-paragraph)


### PR DESCRIPTION
One of my favorite things about typeracer is seeing the source of the text, so I added it here. This doesn't work for all books, since some of the cached versions aren't compatible with this method (see http://www.gutenberg.org/cache/epub/521/pg521.txt and http://www.gutenberg.org/files/521/521.txt). I'm guessing that has to be the case to avoid the captcha, though.
