### PR TITLE
Cosmetic changes in ‘speed-type-stats-format’

### DIFF
--- a/speed-type.el
+++ b/speed-type.el
@@ -87,22 +87,22 @@ Accuracy is computed as (CORRECT-ENTRIES - CORRECTIONS) / TOTAL-ENTRIES."
         ((< wpm 80) "Master")
         (t          "Racer")))
 
-(defvar speed-type-explaining-message "\n
+(defvar speed-type-explaining-message "
 Gross wpm/cpm ignore uncorrected errors and indicate raw speed.
 Net wpm/cpm take uncorrected errors into account and are a measure
 of effective or net speed.")
 
 (defvar speed-type-stats-format "\n
-Skill:\t\t%s
-Net WPM:\t%d
-Net CPM:\t%d
-Gross WPM:\t%d
-Gross CPM:\t%d
-Accuracy:\t%.2f%%
-Total time:\t%s
-Total chars:\t%d
-Corrections:\t%d
-Total errors:\t%d
+Skill:        %s
+Net WPM:      %d
+Net CPM:      %d
+Gross WPM:    %d
+Gross CPM:    %d
+Accuracy:     %.2f%%
+Total time:   %s
+Total chars:  %d
+Corrections:  %d
+Total errors: %d
 %s")
 
 (defun speed-type--generate-stats (entries errors corrections seconds)


### PR DESCRIPTION
Tabs are replaced with spaces because tabs are rendered according to
settings such as ‘tab-width’, which is 8 by default, but many people set
it to different values, 4 for example. When ‘tab-width’ is 4 or even 2
the whole thing looks ugly. Spaces help present statistics in a uniform
way.

I've also removed a newline character in ‘speed-type-explaining-message’
because we already have a newline character in format string, so it
resulted in two newlines. I think since you don't use two newlines as
delimiter for more distinct parts of user interface (such as actual text
and statistics), there is no reason to use two newlines here.
